### PR TITLE
Add pause/resume TAP plan journeys

### DIFF
--- a/server/routes/journeys/temporary-absence-authorisations/edit/confirmation/view.njk
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/confirmation/view.njk
@@ -4,6 +4,8 @@
 {% set pageTitle = 'Change temporary absence authorisation confirmation - Manage temporary absences' %}
 
 {% set EVENT_DESCRIPTION = {
+  'person.temporary-absence-authorisation.paused': 'Absence plan paused',
+  'person.temporary-absence-authorisation.resumed': 'Absence plan resumed',
   'person.temporary-absence-authorisation.date-range-changed': 'Absence date range changed',
   'person.temporary-absence-authorisation.recategorised': 'Absence categorisation changed',
   'person.temporary-absence-authorisation.comments-changed': 'Absence comments changed',

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/controller.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/controller.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response } from 'express'
+import { SchemaType } from './schema'
+import ExternalMovementsService from '../../../../../services/apis/externalMovementsService'
+
+export class TapPauseController {
+  constructor(private readonly externalMovementsService: ExternalMovementsService) {}
+
+  GET = async (req: Request, res: Response) => {
+    res.render('temporary-absence-authorisations/edit/pause/view', {
+      backUrl: req.journeyData.updateTapAuthorisation!.backUrl,
+      reason: res.locals.formResponses?.['reason'],
+      authorisation: req.journeyData.updateTapAuthorisation!.authorisation,
+    })
+  }
+
+  submitToApi = async (req: Request<unknown, unknown, SchemaType>, res: Response, next: NextFunction) => {
+    const journey = req.journeyData.updateTapAuthorisation!
+    try {
+      journey.result = await this.externalMovementsService.updateTapAuthorisation({ res }, journey.authorisation.id, {
+        type: 'PauseAuthorisation',
+        reason: req.body.reason,
+      })
+      next()
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  POST = async (req: Request, res: Response) => {
+    const journey = req.journeyData.updateTapAuthorisation!
+    req.journeyData.journeyCompleted = true
+    res.redirect(
+      journey.result!.content.length ? 'confirmation' : `/temporary-absence-authorisations/${journey.authorisation.id}`,
+    )
+  }
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/routes.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/routes.ts
@@ -1,0 +1,15 @@
+import { Services } from '../../../../../services'
+import { BaseRouter } from '../../../../common/routes'
+import { TapPauseController } from './controller'
+import { validate } from '../../../../../middleware/validation/validationMiddleware'
+import { schema } from './schema'
+
+export const TapPauseRoutes = ({ externalMovementsService }: Services) => {
+  const { router, get, post } = BaseRouter()
+  const controller = new TapPauseController(externalMovementsService)
+
+  get('/', controller.GET)
+  post('/', validate(schema), controller.submitToApi, controller.POST)
+
+  return router
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/schema.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import { createSchema } from '../../../../../middleware/validation/validationMiddleware'
+
+export const schema = createSchema({
+  reason: z.string().refine(val => val.trim(), { message: 'Enter a reason' }),
+})
+
+export type SchemaType = z.infer<typeof schema>

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/test.page.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/test.page.ts
@@ -1,0 +1,17 @@
+import { BaseTestPage } from '../../../../../../integration_tests/pages/baseTestPage'
+
+export class PauseTapAuthorisationPage extends BaseTestPage {
+  async verifyContent() {
+    return this.verify({
+      pageUrl: /\/temporary-absence-authorisations\/edit\/pause/,
+      title: 'Pause absence plan - Manage temporary absences - DPS',
+      caption: 'Manage Temporary Absences',
+      heading: 'Are you sure you want to pause this plan?',
+      backUrl: /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    })
+  }
+
+  reasonField() {
+    return this.textbox(/Enter a reason for temporarily pausing this plan/)
+  }
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/tests.spec.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/tests.spec.ts
@@ -1,0 +1,95 @@
+import { v4 as uuidV4 } from 'uuid'
+import { test, Page, expect } from '@playwright/test'
+import auth from '../../../../../../integration_tests/mockApis/auth'
+import componentsApi from '../../../../../../integration_tests/mockApis/componentsApi'
+import { signIn } from '../../../../../../integration_tests/steps/signIn'
+import { randomPrisonNumber, testTapAuthorisation } from '../../../../../../integration_tests/data/testData'
+import { stubGetPrisonerDetails } from '../../../../../../integration_tests/mockApis/prisonerSearchApi'
+import {
+  stubGetTapAuthorisation,
+  stubPutTapAuthorisation,
+} from '../../../../../../integration_tests/mockApis/externalMovementsApi'
+import { stubGetPrisonerImage } from '../../../../../../integration_tests/mockApis/prisonApi'
+import { PauseTapAuthorisationPage } from './test.page'
+import { testNotAuthorisedPage } from '../../../../../../integration_tests/steps/testNotAuthorisedPage'
+
+test.describe('/temporary-absence-authorisations/edit/pause unauthorised', () => {
+  test('should show unauthorised error', async ({ page }) => {
+    await testNotAuthorisedPage(page, `/${uuidV4()}/temporary-absence-authorisations/edit/pause`)
+  })
+})
+
+test.describe('/temporary-absence-authorisations/edit/pause', () => {
+  const prisonNumber = randomPrisonNumber()
+  const authorisationId = uuidV4()
+
+  const authorisation = {
+    ...testTapAuthorisation,
+    id: authorisationId,
+    person: {
+      personIdentifier: prisonNumber,
+      firstName: 'PRISONER-NAME',
+      lastName: 'PRISONER-SURNAME',
+
+      cellLocation: '2-1-005',
+    },
+    status: { code: 'APPROVED', description: 'approved' },
+    repeat: false,
+  }
+
+  test.beforeAll(async () => {
+    await Promise.all([
+      auth.stubSignIn(),
+      componentsApi.stubComponents(),
+      stubGetPrisonerImage(),
+      stubGetPrisonerDetails({ prisonerNumber: prisonNumber }),
+      stubGetTapAuthorisation(authorisation),
+      stubPutTapAuthorisation(authorisationId, {
+        content: [
+          {
+            user: { username: 'USERNAME', name: 'User Name' },
+            occurredAt: '2025-12-01T17:50:20.421301',
+            domainEvents: ['person.temporary-absence-authorisation.paused'],
+            changes: [{ propertyName: '', previous: '', change: '' }],
+          },
+        ],
+      }),
+    ])
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page)
+  })
+
+  const startJourney = async (page: Page, journeyId: string) => {
+    await page.goto(`/${journeyId}/temporary-absence-authorisations/start-edit/${authorisationId}/pause`)
+  }
+
+  test('should try all cases', async ({ page }) => {
+    const journeyId = uuidV4()
+    await startJourney(page, journeyId)
+
+    // verify page content
+    const testPage = await new PauseTapAuthorisationPage(page).verifyContent()
+
+    await expect(testPage.reasonField()).toBeVisible()
+    await expect(testPage.reasonField()).toHaveValue('')
+    await expect(testPage.button('Pause this absence', true)).toBeVisible()
+    await expect(testPage.button('Do not pause this absence')).toBeVisible()
+    await expect(testPage.button('Do not pause this absence')).toHaveAttribute(
+      'href',
+      /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    )
+
+    // verify validation error
+    await testPage.clickButton('Pause this absence', 0)
+    await testPage.link('Enter a reason').click()
+    await expect(testPage.reasonField()).toBeFocused()
+
+    // verify next page routing
+    await testPage.reasonField().fill(`test`)
+    await testPage.clickButton('Pause this absence', 0)
+
+    expect(page.url()).toMatch(/\/temporary-absence-authorisations\/edit\/confirmation/)
+  })
+})

--- a/server/routes/journeys/temporary-absence-authorisations/edit/pause/view.njk
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/pause/view.njk
@@ -1,0 +1,47 @@
+{% extends "partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+
+{% set pageTitle = 'Pause absence plan - Manage temporary absences' %}
+
+{% block innerContent %}
+  <div class="govuk-width-container">
+    <span class="govuk-caption-l">Manage Temporary Absences</span>
+    <h1 class="govuk-heading-l">Are you sure you want to pause this plan?</h1>
+    {{ govukWarningText({
+      text: "Future occurrences of this absence will be temporarily paused. Any occurrences that take place during the pause will be marked as paused and will not appear at receptions. You can resume this plan at a later date.",
+      iconFallbackText: "Warning"
+    }) }}
+    <form method="post">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+      {{ govukTextarea({
+        id: "reason",
+        name: "reason",
+        errorMessage: validationErrors | findError('reason'),
+        label: {
+          text: "Enter a reason for temporarily pausing this plan",
+          classes: "govuk-label--m",
+          isPageHeading: false
+        },
+        value: approveReason
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          classes: "govuk-button--warning",
+          text: "Pause this absence",
+          preventDoubleClick: true
+        }) }}
+
+        {{ govukButton({
+          classes: "govuk-button--secondary",
+          text: "Do not pause this absence",
+          href: '/temporary-absence-authorisations/' + authorisation.id,
+          preventDoubleClick: true
+        }) }}
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/controller.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/controller.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import ExternalMovementsService from '../../../../../services/apis/externalMovementsService'
+import { SchemaType } from './schema'
 
 export class TapResumeController {
   constructor(private readonly externalMovementsService: ExternalMovementsService) {}
@@ -11,7 +12,12 @@ export class TapResumeController {
     })
   }
 
-  submitToApi = async (req: Request, res: Response, next: NextFunction) => {
+  submitToApi = async (req: Request<unknown, unknown, SchemaType>, res: Response, next: NextFunction) => {
+    if (!req.body.resume) {
+      next()
+      return
+    }
+
     const journey = req.journeyData.updateTapAuthorisation!
     try {
       journey.result = await this.externalMovementsService.updateTapAuthorisation({ res }, journey.authorisation.id, {
@@ -23,11 +29,11 @@ export class TapResumeController {
     }
   }
 
-  POST = async (req: Request, res: Response) => {
+  POST = async (req: Request<unknown, unknown, SchemaType>, res: Response) => {
     const journey = req.journeyData.updateTapAuthorisation!
     req.journeyData.journeyCompleted = true
     res.redirect(
-      journey.result!.content.length ? 'confirmation' : `/temporary-absence-authorisations/${journey.authorisation.id}`,
+      journey.result?.content.length ? 'confirmation' : `/temporary-absence-authorisations/${journey.authorisation.id}`,
     )
   }
 }

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/controller.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/controller.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express'
+import ExternalMovementsService from '../../../../../services/apis/externalMovementsService'
+
+export class TapResumeController {
+  constructor(private readonly externalMovementsService: ExternalMovementsService) {}
+
+  GET = async (req: Request, res: Response) => {
+    res.render('temporary-absence-authorisations/edit/resume/view', {
+      backUrl: req.journeyData.updateTapAuthorisation!.backUrl,
+      authorisation: req.journeyData.updateTapAuthorisation!.authorisation,
+    })
+  }
+
+  submitToApi = async (req: Request, res: Response, next: NextFunction) => {
+    const journey = req.journeyData.updateTapAuthorisation!
+    try {
+      journey.result = await this.externalMovementsService.updateTapAuthorisation({ res }, journey.authorisation.id, {
+        type: 'ResumeAuthorisation',
+      })
+      next()
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  POST = async (req: Request, res: Response) => {
+    const journey = req.journeyData.updateTapAuthorisation!
+    req.journeyData.journeyCompleted = true
+    res.redirect(
+      journey.result!.content.length ? 'confirmation' : `/temporary-absence-authorisations/${journey.authorisation.id}`,
+    )
+  }
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/routes.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/routes.ts
@@ -1,13 +1,15 @@
 import { Services } from '../../../../../services'
 import { BaseRouter } from '../../../../common/routes'
 import { TapResumeController } from './controller'
+import { validate } from '../../../../../middleware/validation/validationMiddleware'
+import { schema } from './schema'
 
 export const TapResumeRoutes = ({ externalMovementsService }: Services) => {
   const { router, get, post } = BaseRouter()
   const controller = new TapResumeController(externalMovementsService)
 
   get('/', controller.GET)
-  post('/', controller.submitToApi, controller.POST)
+  post('/', validate(schema), controller.submitToApi, controller.POST)
 
   return router
 }

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/routes.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/routes.ts
@@ -1,0 +1,13 @@
+import { Services } from '../../../../../services'
+import { BaseRouter } from '../../../../common/routes'
+import { TapResumeController } from './controller'
+
+export const TapResumeRoutes = ({ externalMovementsService }: Services) => {
+  const { router, get, post } = BaseRouter()
+  const controller = new TapResumeController(externalMovementsService)
+
+  get('/', controller.GET)
+  post('/', controller.submitToApi, controller.POST)
+
+  return router
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/schema.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+import { createSchema } from '../../../../../middleware/validation/validationMiddleware'
+
+export const schema = createSchema({
+  resume: z
+    .enum(['YES', 'NO'], { message: 'Select if you want to resume this absence' })
+    .transform(val => val === 'YES'),
+})
+
+export type SchemaType = z.infer<typeof schema>

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/test.page.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/test.page.ts
@@ -1,0 +1,13 @@
+import { BaseTestPage } from '../../../../../../integration_tests/pages/baseTestPage'
+
+export class ResumeTapAuthorisationPage extends BaseTestPage {
+  async verifyContent() {
+    return this.verify({
+      pageUrl: /\/temporary-absence-authorisations\/edit\/resume/,
+      title: 'Resume absence plan - Manage temporary absences - DPS',
+      caption: 'Manage Temporary Absences',
+      heading: 'Are you sure you want to resume this absence plan?',
+      backUrl: /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    })
+  }
+}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/test.page.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/test.page.ts
@@ -10,4 +10,12 @@ export class ResumeTapAuthorisationPage extends BaseTestPage {
       backUrl: /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
     })
   }
+
+  yesRadio() {
+    return this.radio('Yes')
+  }
+
+  noRadio() {
+    return this.radio('No')
+  }
 }

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/tests.spec.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/tests.spec.ts
@@ -1,0 +1,87 @@
+import { v4 as uuidV4 } from 'uuid'
+import { test, Page, expect } from '@playwright/test'
+import auth from '../../../../../../integration_tests/mockApis/auth'
+import componentsApi from '../../../../../../integration_tests/mockApis/componentsApi'
+import { signIn } from '../../../../../../integration_tests/steps/signIn'
+import { randomPrisonNumber, testTapAuthorisation } from '../../../../../../integration_tests/data/testData'
+import { stubGetPrisonerDetails } from '../../../../../../integration_tests/mockApis/prisonerSearchApi'
+import {
+  stubGetTapAuthorisation,
+  stubPutTapAuthorisation,
+} from '../../../../../../integration_tests/mockApis/externalMovementsApi'
+import { stubGetPrisonerImage } from '../../../../../../integration_tests/mockApis/prisonApi'
+import { ResumeTapAuthorisationPage } from './test.page'
+import { testNotAuthorisedPage } from '../../../../../../integration_tests/steps/testNotAuthorisedPage'
+
+test.describe('/temporary-absence-authorisations/edit/resume unauthorised', () => {
+  test('should show unauthorised error', async ({ page }) => {
+    await testNotAuthorisedPage(page, `/${uuidV4()}/temporary-absence-authorisations/edit/resume`)
+  })
+})
+
+test.describe('/temporary-absence-authorisations/edit/resume', () => {
+  const prisonNumber = randomPrisonNumber()
+  const authorisationId = uuidV4()
+
+  const authorisation = {
+    ...testTapAuthorisation,
+    id: authorisationId,
+    person: {
+      personIdentifier: prisonNumber,
+      firstName: 'PRISONER-NAME',
+      lastName: 'PRISONER-SURNAME',
+
+      cellLocation: '2-1-005',
+    },
+    status: { code: 'PAUSED', description: 'Paused' },
+    repeat: false,
+  }
+
+  test.beforeAll(async () => {
+    await Promise.all([
+      auth.stubSignIn(),
+      componentsApi.stubComponents(),
+      stubGetPrisonerImage(),
+      stubGetPrisonerDetails({ prisonerNumber: prisonNumber }),
+      stubGetTapAuthorisation(authorisation),
+      stubPutTapAuthorisation(authorisationId, {
+        content: [
+          {
+            user: { username: 'USERNAME', name: 'User Name' },
+            occurredAt: '2025-12-01T17:50:20.421301',
+            domainEvents: ['person.temporary-absence-authorisation.resume'],
+            changes: [{ propertyName: '', previous: '', change: '' }],
+          },
+        ],
+      }),
+    ])
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page)
+  })
+
+  const startJourney = async (page: Page, journeyId: string) => {
+    await page.goto(`/${journeyId}/temporary-absence-authorisations/start-edit/${authorisationId}/resume`)
+  }
+
+  test('should try all cases', async ({ page }) => {
+    const journeyId = uuidV4()
+    await startJourney(page, journeyId)
+
+    // verify page content
+    const testPage = await new ResumeTapAuthorisationPage(page).verifyContent()
+
+    await expect(testPage.button('Resume this absence', true)).toBeVisible()
+    await expect(testPage.button('Do not resume this absence')).toBeVisible()
+    await expect(testPage.button('Do not resume this absence')).toHaveAttribute(
+      'href',
+      /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    )
+
+    // verify next page routing
+    await testPage.clickButton('Resume this absence', 0)
+
+    expect(page.url()).toMatch(/\/temporary-absence-authorisations\/edit\/confirmation/)
+  })
+})

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/tests.spec.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/tests.spec.ts
@@ -71,17 +71,35 @@ test.describe('/temporary-absence-authorisations/edit/resume', () => {
 
     // verify page content
     const testPage = await new ResumeTapAuthorisationPage(page).verifyContent()
+    await expect(testPage.yesRadio()).toBeVisible()
+    await expect(testPage.yesRadio()).not.toBeChecked()
+    await expect(testPage.noRadio()).toBeVisible()
+    await expect(testPage.noRadio()).not.toBeChecked()
+    await expect(testPage.button('Save', true)).toBeVisible()
 
-    await expect(testPage.button('Resume this absence', true)).toBeVisible()
-    await expect(testPage.button('Do not resume this absence')).toBeVisible()
-    await expect(testPage.button('Do not resume this absence')).toHaveAttribute(
-      'href',
-      /\/temporary-absence-authorisations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
-    )
+    // verify validation error
+    await testPage.clickButton('Save')
+    await testPage.link('Select if you want to resume this absence').click()
+    await expect(testPage.yesRadio()).toBeFocused()
 
     // verify next page routing
-    await testPage.clickButton('Resume this absence', 0)
+    await testPage.yesRadio().click()
+    await testPage.clickButton('Save')
 
     expect(page.url()).toMatch(/\/temporary-absence-authorisations\/edit\/confirmation/)
+  })
+
+  test('should route to TAP plan details page if `No` is selected', async ({ page }) => {
+    const journeyId = uuidV4()
+    await startJourney(page, journeyId)
+
+    // verify page content
+    const testPage = await new ResumeTapAuthorisationPage(page).verifyContent()
+
+    // verify next page routing
+    await testPage.noRadio().click()
+    await testPage.clickButton('Save')
+
+    expect(page.url()).toContain(`/temporary-absence-authorisations/${authorisationId}`)
   })
 })

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/view.njk
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/view.njk
@@ -1,27 +1,41 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set pageTitle = 'Resume absence plan - Manage temporary absences' %}
 
 {% block innerContent %}
   <div class="govuk-width-container">
     <span class="govuk-caption-l">Manage Temporary Absences</span>
-    <h1 class="govuk-heading-l">Are you sure you want to resume this absence plan?</h1>
     <form method="post">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-      <div class="govuk-button-group">
-        {{ govukButton({
-          text: "Resume this absence",
-          preventDoubleClick: true
-        }) }}
+      {{ govukRadios({
+        name: "resume",
+        errorMessage: validationErrors | findError('resume'),
+        fieldset: {
+          legend: {
+            text: "Are you sure you want to resume this absence plan?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        hint: { text: 'Resuming this plan will set future occurrences back to scheduled.' },
+        items: [
+          {
+            value: 'YES',
+            text: "Yes"
+          },
+          {
+            value: 'NO',
+            text: "No"
+          }
+        ]
+      }) }}
 
-        {{ govukButton({
-          classes: "govuk-button--secondary",
-          text: "Do not resume this absence",
-          href: '/temporary-absence-authorisations/' + authorisation.id,
-          preventDoubleClick: true
-        }) }}
-      </div>
+      {{ govukButton({
+        text: "Save",
+        preventDoubleClick: true
+      }) }}
     </form>
   </div>
 {% endblock %}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/resume/view.njk
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/resume/view.njk
@@ -1,0 +1,27 @@
+{% extends "partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = 'Resume absence plan - Manage temporary absences' %}
+
+{% block innerContent %}
+  <div class="govuk-width-container">
+    <span class="govuk-caption-l">Manage Temporary Absences</span>
+    <h1 class="govuk-heading-l">Are you sure you want to resume this absence plan?</h1>
+    <form method="post">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Resume this absence",
+          preventDoubleClick: true
+        }) }}
+
+        {{ govukButton({
+          classes: "govuk-button--secondary",
+          text: "Do not resume this absence",
+          href: '/temporary-absence-authorisations/' + authorisation.id,
+          preventDoubleClick: true
+        }) }}
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/server/routes/journeys/temporary-absence-authorisations/edit/routes.ts
+++ b/server/routes/journeys/temporary-absence-authorisations/edit/routes.ts
@@ -17,6 +17,8 @@ import { EditTapAuthorisationAccompaniedOrUnaccompaniedRoutes } from './accompan
 import { EditTapAuthorisationAccompaniedRoutes } from './accompanied/routes'
 import { EditTapAuthorisationTransportRoutes } from './transport/routes'
 import journeyStateGuard from '../../../../middleware/journey/journeyStateGuard'
+import { TapPauseRoutes } from './pause/routes'
+import { TapResumeRoutes } from './resume/routes'
 
 export const EditTapAuthorisationRoutes = (services: Services) => {
   const { router, get } = BaseRouter()
@@ -45,6 +47,8 @@ export const EditTapAuthorisationRoutes = (services: Services) => {
   router.use('/transport', EditTapAuthorisationTransportRoutes(services))
 
   router.use('/cancel', TapCancelRoutes(services))
+  router.use('/pause', TapPauseRoutes(services))
+  router.use('/resume', TapResumeRoutes(services))
   router.use('/review', TapReviewRoutes())
   router.use('/review-reason', TapReviewReasonRoutes(services))
 

--- a/server/routes/temporary-absence-authorisations/details/controller.ts
+++ b/server/routes/temporary-absence-authorisations/details/controller.ts
@@ -38,9 +38,13 @@ export class TapAuthorisationDetailsController {
             uprn || description?.length || address?.length || postcode?.length,
         )
       const cancellable =
-        authorisation.status.code === 'APPROVED' &&
+        (authorisation.status.code === 'APPROVED' || authorisation.status.code === 'PAUSED') &&
         (authorisation.repeat ||
           !['IN_PROGRESS', 'OVERDUE', 'COMPLETED'].includes(authorisation.occurrences[0]?.status.code ?? ''))
+      const pausable =
+        authorisation.status.code === 'APPROVED' &&
+        authorisation.occurrences.every(({ status }) => !['IN_PROGRESS', 'OVERDUE'].includes(status.code))
+      const resumable = authorisation.status.code === 'PAUSED'
 
       res.render('temporary-absence-authorisations/details/view', {
         showBreadcrumbs: true,
@@ -51,6 +55,8 @@ export class TapAuthorisationDetailsController {
         editable,
         approvable,
         cancellable,
+        pausable,
+        resumable,
       })
     } catch (error: unknown) {
       if ((error as { message?: string }).message) {

--- a/server/routes/temporary-absence-authorisations/details/view.njk
+++ b/server/routes/temporary-absence-authorisations/details/view.njk
@@ -31,6 +31,21 @@
                   preventDoubleClick: true
                 }) }}
               {% endif %}
+              {% if pausable %}
+                {{ govukButton({
+                  classes: "govuk-button--secondary",
+                  text: "Temporarily pause this plan",
+                  href: baseEditUrl + "/pause",
+                  preventDoubleClick: true
+                }) }}
+              {% endif %}
+              {% if resumable %}
+                {{ govukButton({
+                  text: "Resume this absence",
+                  href: baseEditUrl + "/resume",
+                  preventDoubleClick: true
+                }) }}
+              {% endif %}
               {% if cancellable %}
                 {{ govukButton({
                   classes: "govuk-button--warning",

--- a/server/routes/temporary-absence-authorisations/schema.ts
+++ b/server/routes/temporary-absence-authorisations/schema.ts
@@ -4,7 +4,7 @@ import { createSchema } from '../../middleware/validation/validationMiddleware'
 import { validateTransformOptionalDate } from '../../utils/validations/validateDatePicker'
 import { isPrisonNumber } from '../../utils/utils'
 
-const statusEnum = z.enum(['PENDING', 'APPROVED', 'CANCELLED', 'DENIED', 'EXPIRED'])
+const statusEnum = z.enum(['PENDING', 'APPROVED', 'CANCELLED', 'DENIED', 'EXPIRED', 'PAUSED'])
 
 export const schema = createSchema({
   searchTerm: z.string().optional(),

--- a/server/routes/temporary-absence-authorisations/view.njk
+++ b/server/routes/temporary-absence-authorisations/view.njk
@@ -87,6 +87,10 @@
                     text: 'Expired'
                   },
                   {
+                    value: 'PAUSED',
+                    text: 'Paused'
+                  },
+                  {
                     value: 'CANCELLED',
                     text: "Cancelled"
                   },

--- a/server/utils/parseAuditHistory.ts
+++ b/server/utils/parseAuditHistory.ts
@@ -121,6 +121,24 @@ const DOMAIN_EVENT_MAP: { [key: string]: DomainEventText } = {
     content: 'Temporary absence movement migrated from NOMIS',
     skipUser: true,
   },
+  'person.temporary-absence-authorisation.paused': {
+    heading: 'Absence plan paused',
+    content: 'Temporary absence paused for <prisoner>',
+    reasonRequested: true,
+  },
+  'person.temporary-absence.paused': {
+    heading: 'Absence paused',
+    content: 'Temporary absence occurrence paused for <prisoner>',
+    reasonRequested: true,
+  },
+  'person.temporary-absence-authorisation.resumed': {
+    heading: 'Absence plan resumed',
+    content: 'Temporary absence resumed for <prisoner>',
+  },
+  'person.temporary-absence.resumed': {
+    heading: 'Absence resumed',
+    content: 'Temporary absence occurrence resumed for <prisoner>',
+  },
 }
 
 const CHANGE_PROPERTY_MAP: { [key: string]: string } = {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -149,7 +149,7 @@ export const isTapAuthorisationEditable = ({
   occurrences?: components['schemas']['TapAuthorisation.Occurrence'][]
   repeat: boolean
 }) =>
-  ['PENDING', 'APPROVED'].includes(status.code) &&
+  ['PENDING', 'APPROVED', 'PAUSED'].includes(status.code) &&
   end >= format(new Date(), 'yyyy-MM-dd') &&
   (repeat || !(occurrences?.length === 0))
 

--- a/server/views/partials/absenceStatusTag/macro.njk
+++ b/server/views/partials/absenceStatusTag/macro.njk
@@ -6,7 +6,7 @@
   {% case 'PENDING' %}
     {% set colour = " govuk-tag--grey" %}
   {% case 'PAUSED' %}
-    {% set colour = " govuk-tag--grey" %}
+    {% set colour = " govuk-tag--orange" %}
   {% case 'SCHEDULED' %}
     {% set colour = " govuk-tag--yellow" %}
   {% case 'IN_PROGRESS' %}

--- a/server/views/partials/absenceStatusTag/macro.njk
+++ b/server/views/partials/absenceStatusTag/macro.njk
@@ -5,6 +5,8 @@
     {% set colour = " govuk-tag--green" %}
   {% case 'PENDING' %}
     {% set colour = " govuk-tag--grey" %}
+  {% case 'PAUSED' %}
+    {% set colour = " govuk-tag--grey" %}
   {% case 'SCHEDULED' %}
     {% set colour = " govuk-tag--yellow" %}
   {% case 'IN_PROGRESS' %}


### PR DESCRIPTION
MIA-1774

pause journey:
<img width="1254" height="976" alt="image" src="https://github.com/user-attachments/assets/c0afcf57-5770-4a3a-81d8-eb280b245a96" />

<img width="936" height="858" alt="image" src="https://github.com/user-attachments/assets/2e2bc204-1610-4ca4-a463-ba2c656964ed" />

<img width="905" height="574" alt="image" src="https://github.com/user-attachments/assets/cf2e4979-32d6-4df5-8bfc-7b877b26a339" />

resume journey:
<img width="611" height="243" alt="image" src="https://github.com/user-attachments/assets/178d412e-d3a2-4356-a685-0a6960d11f65" />

<img width="1237" height="996" alt="image" src="https://github.com/user-attachments/assets/bd34e563-f125-429b-bb5a-d7f34a62113b" />

<img width="1217" height="711" alt="image" src="https://github.com/user-attachments/assets/c5acb10a-aec9-473c-9219-3013e43e9521" />

Audit history:
<img width="860" height="787" alt="image" src="https://github.com/user-attachments/assets/783f4d92-f494-4120-a492-34f65b339317" />

<img width="815" height="778" alt="image" src="https://github.com/user-attachments/assets/31a0ea9c-10b0-4683-984e-48c3f69fab5e" />


